### PR TITLE
Simplify executable name.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ dart:
   - stable
 script:
   - pub run test
-  - pub run dart_codecov_generator:generate_coverage --report-on=bin/ --no-html --verbose
+  - pub run dart_codecov_generator --report-on=bin/ --no-html --verbose
   - pub run dart_codecov coverage.lcov

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 > Generate code coverage for Dart projects. Output can be [lcov](http://ltp.sourceforge.net/coverage/lcov.php) format or an HTML report.
 
-This project includes a `generate_coverage` executable that runs one or many test files and uses the `coverage` package to collect coverage for each file and format the coverage into the desired output format.
+This project includes a `dart_codecov_generator` executable that runs one or many test files and uses the `coverage` package to collect coverage for each file and format the coverage into the desired output format.
 
 
 ## Prerequisites
@@ -36,14 +36,14 @@ pub get
 
 ## Usage
 ```
-pub run dart_codecov_generator:generate_coverage
+pub run dart_codecov_generator
 ```
 
 
 ## Configuration
 By default, this tool runs every test file in the `test/` directory. You can explicitly specify the directories or files like so:
 ```
-dart_codecov_generator:generate_coverage test/my_test.dart
+pub run dart_codecov_generator test/my_test.dart
 ```
 
 ### Options

--- a/bin/dart_codecov_generator.dart
+++ b/bin/dart_codecov_generator.dart
@@ -1,0 +1,3 @@
+library dart_codecov_generator.bin.dart_codecov_generator;
+
+export 'src/executable.dart';

--- a/bin/generate_coverage.dart
+++ b/bin/generate_coverage.dart
@@ -1,3 +1,10 @@
 library dart_codecov_generator.bin.generate_coverage;
 
-export 'src/executable.dart';
+import 'src/executable.dart' as executable;
+
+
+void main(List<String> args) {
+  print('Warning: `pub run dart_codecov_generator:generate_coverage` is deprecated.');
+  print('Use `pub run dart_codecov_generator` instead.\n');
+  executable.main(args);
+}


### PR DESCRIPTION
Deprecate `dart_codecov_generator:generate_coverage` in favor of the simplified and self-named `dart_codecov_generator` exectuable.

**Old:**
```
pub run dart_codecov_generator:generate_coverage
```

**New:**
```
pub run dart_codecov_generator
```

> A deprecate notice will be output to console when using the old version.